### PR TITLE
Wording and corrections in examples

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 before_script:
-  # Tomb and pass dependencies
+  # tomb and pass dependencies
   - export DEBIAN_FRONTEND=noninteractive
   - sudo apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confnew" install --no-install-recommends -y git tree zsh sudo gnupg cryptsetup pinentry-curses gawk  libgcrypt20-dev steghide qrencode e2fsprogs shellcheck dcfldd steghide qrencode
   - sudo swapoff -a

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ all:
 	@echo ""
 	@echo "To install it try \"make install\" instead."
 	@echo
-	@echo "To run pass $(PROG) one needs to have some tools installed on the system:"
-	@echo "     Tomb and password store"
+	@echo "To run pass-$(PROG) one needs to have some tools installed on the system:"
+	@echo "     tomb and pass."
 
 install:
 	@install -v -d "$(DESTDIR)$(MANDIR)/man1" && install -m 0644 -v pass-$(PROG).1 "$(DESTDIR)$(MANDIR)/man1/pass-$(PROG).1"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ manage your password store in a tomb.
 ## Description
 
 Due to the structure of `pass`, file- and directory names are not encrypted in
-the password store. `pass-tomb` provides a convenient solution to put you password
+the password store. `pass-tomb` provides a convenient solution to put your password
 store in a [tomb](https://github.com/dyne/Tomb) and then keep your password
 tree encrypted when you are not using it.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ manage your password store in a tomb.
 
 ## Description
 
-Due to the structure of `pass`, files and directories names are not encrypted in
+Due to the structure of `pass`, file- and directory names are not encrypted in
 the password store. `pass-tomb` provides a convenient solution to put you password
 store in a [tomb](https://github.com/dyne/Tomb) and then keep your password
 tree encrypted when you are not using it.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # pass tomb [![build status][build-img]][build-url]
 
 A [pass](https://www.passwordstore.org/) extension allowing you to put and
-manage your password repository in a tomb.
+manage your password store in a tomb.
 
 ## Description
 
 Due to the structure of `pass`, files and directories names are not encrypted in
 the password store. `pass-tomb` provides a convenient solution to put you password
-repository in a [tomb](https://github.com/dyne/Tomb) and then keep your password
+store in a [tomb](https://github.com/dyne/Tomb) and then keep your password
 tree encrypted when you are not using it.
 
 It uses the same GPG key to encrypt passwords and tomb.
@@ -15,9 +15,9 @@ It uses the same GPG key to encrypt passwords and tomb.
 The new workflow is the following:
 * Create a password tomb with `pass tomb`
  - Create a new tomb and open it in `~/.password-store`
- - Initialize the password repository with the same GPG key.
+ - Initialise the password repository with the same GPG key
 * Use tomb as usual
-* When finished close the password tomb: `pass close`
+* When finished, close the password tomb: `pass close`
 * To use pass again, you need to open the password tomb: `pass open`
 
 ## Examples
@@ -25,7 +25,7 @@ The new workflow is the following:
 **Create a new password tomb**
 ```
 $ pass tomb <gpg-id>
- (*) Your password tomb as been created and openned in ~/.password-store.
+ (*) Your password tomb has been created and opened in ~/.password-store.
  (*) Password store initialized for <gpg-id>
   .  Your tomb is: ~/password
   .  Your tomb key is: ~/password.key
@@ -36,23 +36,23 @@ $ pass tomb <gpg-id>
 **Open a password tomb**
 ```
 $ pass open
- (*) Your password tomb as been closed
-  .  Your passwords remain present in ~/password
+ (*) Your password tomb has been opened in ~/.password-store.
+  .  You can now use pass as usual.
+  .  When finished, close the password tomb using 'pass close'.
 ```
 
 **Close a password tomb**
 ```
 $ pass close
- (*) Your password tomb as been openned in ~/.password-store.
-  .  You can now use pass as usual
-  .  When finished, close the password tomb using 'pass close'
-```
+ (*) Your password tomb has been closed.
+  .  Your passwords remain present in ~/password.
+  ```
 
 ## Usage
 
 		Usage:
 		    pass tomb [--path=subfolder,-p subfolder] gpg-id...
-		        Create and initialise a new password tomb.
+		        Create and initialise a new password tomb
 		        Use gpg-id for encryption of both tomb and passwords
 		    pass open
 		        Open a password tomb
@@ -62,21 +62,21 @@ $ pass close
 		Options:
 		    -v, --verbose  Print tomb message
 		    -d, --debug    Print tomb debug message
-		        --unsafe   Speed up tomb creation (for test only)
+		          --unsafe   Speed up tomb creation (for test only)
 		    -V, --version  Show version information.
-		    -h, --help	   Print this help message and exit.
+		    -h, --help	     Print this help message and exit.
 
 		More information may be found in the pass-tomb(1) man page.
 
 
-See `man pass-tomb` for more information on import process
+See `man pass-tomb` for more information.
 
 ## Environment Variables
 
-* `PASSWORD_STORE_TOMB`: Path to `tomb`
-* `PASSWORD_STORE_TOMB_FILE`: Path to the password tomb. (default: `~/password`)
-* `PASSWORD_STORE_TOMB_KEY`: Path to the password tomb key file. (default: `~/password.key`)
-* `PASSWORD_STORE_TOMB_SIZE`: Password tomb size in MB (default: `10`)
+* `PASSWORD_STORE_TOMB`: path to `tomb` executable
+* `PASSWORD_STORE_TOMB_FILE`: path to the password tomb (default: `~/password`)
+* `PASSWORD_STORE_TOMB_KEY`: path to the password tomb key file (default: `~/password.key`)
+* `PASSWORD_STORE_TOMB_SIZE`: password tomb size in MB (default: `10`)
 
 ## Installation
 
@@ -84,7 +84,7 @@ See `man pass-tomb` for more information on import process
 
 		pacaur -S pass-tomb
 
-**Other linux**
+**Other linuxes**
 
 		git clone https://gitlab.com/roddhjav/pass-tomb/
 		cd pass-tomb
@@ -92,8 +92,7 @@ See `man pass-tomb` for more information on import process
 
 **Requirments**
 
-* `tomb` with GnuPG Key Support. As of today this version has not been released
-yet. Therefore you need to install it by hand:
+* `tomb` with GnuPG Key Support. Currently unreleased. Therefore you need to install it by hand:
 
 		git clone https://github.com/dyne/Tomb.git
 		cd Tomb

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ It uses the same GPG key to encrypt passwords and tomb.
 The new workflow is the following:
 * Create a password tomb with `pass tomb`
  - Create a new tomb and open it in `~/.password-store`
- - Initialise the password repository with the same GPG key
+ - Initialise the password store with the same GPG key
 * Use tomb as usual
 * When finished, close the password tomb: `pass close`
 * To use pass again, you need to open the password tomb: `pass open`

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ $ pass close
 		Options:
 		    -v, --verbose  Print tomb message
 		    -d, --debug    Print tomb debug message
-		          --unsafe   Speed up tomb creation (for test only)
+		          --unsafe   Speed up tomb creation (for testing only)
 		    -V, --version  Show version information.
 		    -h, --help	     Print this help message and exit.
 

--- a/close.bash
+++ b/close.bash
@@ -16,12 +16,12 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-if [[ -x "$PASSWORD_STORE_EXTENSIONS_DIR/tomb.bash" ]]; then
-	source "$PASSWORD_STORE_EXTENSIONS_DIR/tomb.bash"
-elif [[ -x "$SYSTEM_EXTENSION_DIR/tomb.bash" ]]; then
-	source "$SYSTEM_EXTENSION_DIR/tomb.bash"
+if [[ -x "${PASSWORD_STORE_EXTENSIONS_DIR}/tomb.bash" ]]; then
+	source "${PASSWORD_STORE_EXTENSIONS_DIR}/tomb.bash"
+elif [[ -x "${SYSTEM_EXTENSION_DIR}/tomb.bash" ]]; then
+	source "${SYSTEM_EXTENSION_DIR}/tomb.bash"
 else
-	die "Unable to load the pass tomb extension"
+	die "Unable to load the pass tomb extension."
 fi
 
 cmd_close "$@"

--- a/open.bash
+++ b/open.bash
@@ -16,12 +16,12 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-if [[ -x "$PASSWORD_STORE_EXTENSIONS_DIR/tomb.bash" ]]; then
-	source "$PASSWORD_STORE_EXTENSIONS_DIR/tomb.bash"
-elif [[ -x "$SYSTEM_EXTENSION_DIR/tomb.bash" ]]; then
-	source "$SYSTEM_EXTENSION_DIR/tomb.bash"
+if [[ -x "${PASSWORD_STORE_EXTENSIONS_DIR}/tomb.bash" ]]; then
+	source "${PASSWORD_STORE_EXTENSIONS_DIR}/tomb.bash"
+elif [[ -x "${SYSTEM_EXTENSION_DIR}/tomb.bash" ]]; then
+	source "${SYSTEM_EXTENSION_DIR}/tomb.bash"
 else
-	die "Unable to load the pass tomb extension"
+	die "Unable to load the pass tomb extension."
 fi
 
 cmd_open "$@"

--- a/pass-tomb.1
+++ b/pass-tomb.1
@@ -2,7 +2,7 @@
 
 .SH NAME
 pass import - A \fBpass\fP(1) extension allowing you to put and manage your
-password repository in a \fBtomb\fP(1).
+password store in a \fBtomb\fP(1).
 
 
 .SH SYNOPSIS
@@ -13,9 +13,9 @@ password repository in a \fBtomb\fP(1).
 \fBpass close\fP
 
 .SH DESCRIPTION
-Due to the structure of \fBpass\fP(1), files and directories names are not encrypted
-in the password store. \fBpass tomb\fP provides a convenient solution to put you
-password repository in a \fBtomb\fP(1) and then keep your password tree encrypted
+Due to the structure of \fBpass\fP(1), file- and directory names are not encrypted
+in the password store. \fBpass tomb\fP provides a convenient solution to put your
+password store in a \fBtomb\fP(1) and then keep your password tree encrypted
 when you are not using it.
 
 It uses the same GPG key to encrypt passwords and tomb.
@@ -23,31 +23,31 @@ It uses the same GPG key to encrypt passwords and tomb.
 .TP
 .B The new workflow is the following:
 .IP
-1. Create a password tomb with \fBpass tomb\fP. It creates a new tomb and open it
-in ~/.password-store. Then it initializes the password repository with the same
+1. Create a password tomb with \fBpass tomb\fP. It creates a new tomb and opens it
+in ~/.password-store. Then it initialises the password repository with the same
 GPG key.
 .IP
-2. Use tomb as usual
+2. Use tomb as usual.
 .IP
-3. When finished close the password tomb: \fBpass close\fP
+3. When finished close the password tomb: \fBpass close\fP.
 .IP
-4. To use pass again, you need to open the password tomb: \fBpass open\fP
+4. To use pass again, you need to open the password tomb: \fBpass open\fP.
 
 
 .SH COMMAND
 
 .TP
-\fBpass tomb\fP [ \fI--path=sub-folder\fP, \fI-p sub-folder\fP ] \fIgpg-id...\fP
+\fBpass tomb\fP [ \fI--path=subfolder\fP, \fI-p subfolder\fP ] \fIgpg-id...\fP
 Create and initialise a new password tomb. Use
 .I gpg-id
 for encryption of both passwords and tomb. Multiple gpg-ids may be specified,
 in order to encrypt the tomb and each password with multiple ids. This command
-must be run first before a password store can be used. Note that use of
+must be run first, before a password store can be used. Note that use of
 .BR gpg-agent (1)
 is recommended so that the batch decryption does not require as much user
 intervention. If \fI--path\fP or \fI-p\fP is specified, along with an argument,
 a specific password tomb using gpg-id or a set of gpg-ids is assigned for that
-specific sub folder of the password store.
+specific subfolder of the password store.
 
 .TP
 \fBpass open\fP
@@ -68,15 +68,15 @@ Print tomb message
 
 .TP
 \fB\-\-unsafe\fR
-Speed up tomb creation (for test only
+Speed up tomb creation (for testing only)
 
 .TP
 \fB\-V\fB, \-\-version\fR
-Show version information.
+Show version information
 
 .TP
 \fB\-h\fB, \-\-help\fR
-Show usage message.
+Show usage message
 
 
 .SH EXAMPLES
@@ -84,52 +84,51 @@ Show usage message.
 Create a new password tomb
 .B zx2c4@laptop ~ $ pass tomb Jason@zx2c4.com
 .br
- (*) Your password tomb as been created and openned in ~/.password-store.
+ (*) Your password tomb has been created and opened in ~/.password-store.
 .br
- (*) Password store initialized for Jason@zx2c4.com
+ (*) Password store initialised for Jason@zx2c4.com.
 .br
-  .  Your tomb is: ~/password
+  .  Your tomb is: ~/password.
 .br
-  .  Your tomb key is: ~/password.key
+  .  Your tomb key is: ~/password.key.
 .br
-  .  You can now use pass as usual
+  .  You can now use pass as usual.
 .br
-  .  When finished, close the password tomb using 'pass close'
+  .  When finished, close the password tomb using 'pass close'.
 
 .TP
 Open a password tomb
 .B zx2c4@laptop ~ $ pass open
 .br
- (*) Your password tomb as been closed
+ (*) Your password tomb has been opened in ~/.password-store.
 .br
-  .  Your passwords remain present in ~/password
-
+  .  You can now use pass as usual.
+.br
+  .  When finished, close the password tomb using 'pass close'.
+  
 .TP
 Close a password tomb
 .B zx2c4@laptop ~ $ pass close
 .br
- (*) Your password tomb as been openned in ~/.password-store.
+ (*) Your password tomb has been closed.
 .br
-  .  You can now use pass as usual
-.br
-  .  When finished, close the password tomb using 'pass close'
-
-
+  .  Your passwords remain present in ~/password.
+  
 
 
 .SH ENVIRONMENT VARIABLES
 .TP
 .I PASSWORD_STORE_TOMB
-Path to tomb
+Path to tomb executable
 .TP
 .I PASSWORD_STORE_TOMB_FILE
-Path to the password tomb, by default \fI~/password\fP.
+Path to the password tomb, by default \fI~/password\fP
 .TP
 .I PASSWORD_STORE_TOMB_KEY
-Path to the password tomb key file by default \fI~/password.key\fP.
+Path to the password tomb key file by default \fI~/password.key\fP
 .TP
 .I PASSWORD_STORE_TOMB_SIZE
-Password tomb size in MB, by default \fI10\fP.
+Password tomb size in MB, by default \fI10\fP
 
 
 .SH SEE ALSO

--- a/tests/runtests
+++ b/tests/runtests
@@ -18,7 +18,7 @@
 
 # Test units suite
 
-# WARNING: This test suite will slam all running tomb on your system.
+# WARNING: This test suite will slam all running tombs on your system.
 
 #
 # pass config
@@ -44,7 +44,7 @@ pass_populate() {
 
 
 #
-# Commons color and functions
+# Common colors and functions
 #
 red='\e[0;31m'
 green='\e[0;32m'
@@ -98,7 +98,7 @@ KEY5="4D2AFBDE67C60F5999D143AFA6E073D439E5020C"
 notice "Loading test suite"
 
 pass_tomb() {
-	notice "Testing password tomb creation and store initialisation."
+	notice "Testing password tomb creation and store initialisation"
 	pass tomb "$KEY1" --verbose --unsafe
 	test $? = 0 && results[pass-tomb]=SUCCESS
 
@@ -165,7 +165,7 @@ for t in ${tests[@]}; do
 	fi
 done
 
-success "Done. You can remove temporary leftovers from $PASSWORD_STORE_DIR/"
+success "Done. You can remove temporary leftovers from ${PASSWORD_STORE_DIR}/"
 
 unset PASSWORD_STORE_ENABLE_EXTENSIONS
 unset PASSWORD_STORE_EXTENSIONS_DIR
@@ -177,7 +177,7 @@ unset PASSWORD_STORE_SIGNING_KEY
 [ $GLOBAL_RESULT = 0 ] && {
 	success "Tests passed"
 } || {
-	error "Tests failded"
+	error "Tests failed"
 }
 
 exit $GLOBAL_RESULT

--- a/tomb.bash
+++ b/tomb.bash
@@ -22,7 +22,7 @@ TOMB_KEY="${PASSWORD_STORE_TOMB_KEY:-$HOME/password.key}"
 TOMB_SIZE="${PASSWORD_STORE_TOMB_SIZE:-10}"
 
 #
-# Commons color and functions
+# Common colors and functions
 #
 green='\e[0;32m'
 yellow='\e[0;33m'
@@ -45,7 +45,7 @@ _verbose() { [ "$VERBOSE" = 0 ] || _alert "${@}"; }
 #
 # pass tomb depends on tomb
 _ensure_dependencies() {
-	command -v "$TOMB" 1>/dev/null 2>/dev/null || _die "Tomb is not present"
+	command -v "$TOMB" 1>/dev/null 2>/dev/null || _die "Tomb is not present."
 }
 
 # $@ is the list of all the recipient used to encrypt a tomb key
@@ -57,7 +57,7 @@ is_valid_recipients() {
 	for gpg_id in "${recipients[@]}"; do
 		gpg --list-keys "$gpg_id" &> /dev/null
 		[[ $? != 0 ]] && {
-			_warning "$gpg_id is not a valid key ID."
+			_warning "${gpg_id} is not a valid key ID."
 			return 1
 		}
 	done
@@ -79,7 +79,7 @@ _tomb() {
 	while read ii; do
 		_verbose "$ii"
 	done <$TMP
-	[[ $ret == 0 ]] || _die "Unable to $cmd the password tomb"
+	[[ $ret == 0 ]] || _die "Unable to ${cmd} the password tomb."
 }
 
 # Provide a random filename in shared memory
@@ -89,14 +89,14 @@ _tmp_create() {
 
 	umask 066
 	[[ $? == 0 ]] || {
-		_die "Fatal error setting the permission umask for temporary files"; }
+		_die "Fatal error setting the permission umask for temporary files."; }
 
 	[[ -r "$tfile" ]] && {
 		_die "Someone is messing up with us trying to hijack temporary files."; }
 
 	touch "$tfile"
 	[[ $? == 0 ]] || {
-		_die "Fatal error creating a temporary file: $tfile"; }
+		_die "Fatal error creating a temporary file: ${tfile}."; }
 
 	TMP="$tfile"
 	return 0
@@ -109,14 +109,14 @@ _set_ownership() {
 	local uid="$(id -u $USER)"
 	local gid="$(id -g $USER)"
 
-	sudo chown -R $uid:$gid "$path" || _die "Unable to set the permission on $path"
-	sudo chmod 0711 "$path" || _die "Unable to set the permission on $path"
+	sudo chown -R $uid:$gid "$path" || _die "Unable to set ownership permission on ${path}."
+	sudo chmod 0711 "$path" || _die "Unable to set permissions on ${path}."
 }
 
 cmd_tomb_verion() {
 	cat <<-_EOF
 	$PROGRAM tomb - A pass extension allowing you to put and manage your
-	            password repository in a tomb.
+	            password store in a tomb.
 
 	Vesion: 0.1
 	_EOF
@@ -128,7 +128,7 @@ cmd_tomb_usage() {
 	cat <<-_EOF
 	Usage:
 	    $PROGRAM tomb [--path=subfolder,-p subfolder] gpg-id...
-	        Create and initialise a new password tomb.
+	        Create and initialise a new password tomb
 	        Use gpg-id for encryption of both tomb and passwords
 	    $PROGRAM open
 	        Open a password tomb
@@ -138,9 +138,9 @@ cmd_tomb_usage() {
 	Options:
 	    -v, --verbose  Print tomb message
 	    -d, --debug    Print tomb debug message
-	        --unsafe   Speed up tomb creation (for test only)
+	          --unsafe   Speed up tomb creation (for testing only)
 	    -V, --version  Show version information.
-	    -h, --help	   Print this help message and exit.
+	    -h, --help	     Print this help message and exit.
 
 	More information may be found in the pass-tomb(1) man page.
 	_EOF
@@ -155,12 +155,12 @@ cmd_open() {
 	[[ -e "$TOMB_KEY" ]] || _die "There is no password tomb key."
 
 	_tmp_create
-	_tomb open "$TOMB_FILE" -k "$TOMB_KEY" -g "$PREFIX/$path"
-	_set_ownership "$PREFIX/$path"
+	_tomb open "$TOMB_FILE" -k "$TOMB_KEY" -g "${PREFIX}/${path}"
+	_set_ownership "${PREFIX}/${path}"
 
-	_success "Your password tomb as been openned in $PREFIX/."
-	_message "You can now use pass as usual"
-	_message "When finished, close the password tomb using 'pass close'"
+	_success "Your password tomb has been openned in ${PREFIX}/."
+	_message "You can now use pass as usual."
+	_message "When finished, close the password tomb using 'pass close'."
 	return 0
 }
 
@@ -171,13 +171,13 @@ cmd_close() {
 	[[ -e "$TOMB_FILE" ]] || _die "There is no password tomb to close."
 	TOMB_NAME=${TOMB_FILE##*/}
 	TOMB_NAME=${TOMB_NAME%.*}
-	[[ -z "$TOMB_NAME" ]] && _die "There no password tomb."
+	[[ -z "$TOMB_NAME" ]] && _die "There is no password tomb."
 
 	_tmp_create
 	_tomb close "$TOMB_NAME"
 
-	_success "Your password tomb as been closed"
-	_message "Your passwords remain present in $TOMB_FILE"
+	_success "Your password tomb has been closed."
+	_message "Your passwords remain present in ${TOMB_FILE}."
 	return 0
 }
 
@@ -196,15 +196,15 @@ cmd_tomb() {
 	if ! is_valid_recipients "${RECIPIENTS[@]}"; then
 		_die "You set an invalid GPG ID."
 	elif [[ -e "$TOMB_KEY" ]]; then
-		_die "The tomb key $TOMB_KEY already exists. I won't overwrite it."
+		_die "The tomb key ${TOMB_KEY} already exists. I won't overwrite it."
 	elif [[ -e "$TOMB_FILE" ]]; then
-		_die "The password tomb $TOMB_FILE already exists. I won't overwrite it."
+		_die "The password tomb ${TOMB_FILE} already exists. I won't overwrite it."
 	elif [[ "$TOMB_SIZE" -lt 10 ]]; then
 		_die "A password tomb cannot be smaller than 10 MB."
 	fi
 	if [[ $UNSAFE -ne 0 ]]; then
 		_warning "Using unsafe mode to speed up tomb generation."
-		_warning "Only use it for test purpose."
+		_warning "Only use it for testing purposes."
 		local unsafe="--unsafe --use-urandom"
 	fi
 
@@ -223,23 +223,23 @@ cmd_tomb() {
 	_tomb dig "$TOMB_FILE" -s "$TOMB_SIZE"
 	_tomb forge "$TOMB_KEY" -gr "$recipients_arg" $shared $unsafe
 	_tomb lock "$TOMB_FILE" -k "$TOMB_KEY" -gr "$recipients_arg"
-	_tomb open "$TOMB_FILE" -k "$TOMB_KEY" -gr "$recipients_arg" "$PREFIX/$path"
-	_set_ownership "$PREFIX/$path"
+	_tomb open "$TOMB_FILE" -k "$TOMB_KEY" -gr "$recipients_arg" "${PREFIX}/${path}"
+	_set_ownership "${PREFIX}/${path}"
 
 	# Use the same recipients to initialise the password store
 	local ret path_cmd
 	[ -z "$path" ] || path_cmd="--path=$path"
 	ret=$(cmd_init "${RECIPIENTS[@]}" $path_cmd)
-	if [[ -e "$PREFIX/$path/.gpg-id" ]]; then
-		_success "Your password tomb as been created and openned in $PREFIX."
+	if [[ -e "${PREFIX}/${path}/.gpg-id" ]]; then
+		_success "Your password tomb has been created and opened in ${PREFIX}."
 		_success "$ret"
-		_message "Your tomb is: $TOMB_FILE"
-		_message "Your tomb key is: $TOMB_KEY"
-		_message "You can now use pass as usual"
-		_message "When finished, close the password tomb using 'pass close'"
+		_message "Your tomb is: ${TOMB_FILE}"
+		_message "Your tomb key is: ${TOMB_KEY}"
+		_message "You can now use pass as usual."
+		_message "When finished, close the password tomb using 'pass close'."
 	else
 		_warning "$ret"
-		_die "Unable to initialise the password store"
+		_die "Unable to initialise the password store."
 	fi
 	return 0
 }


### PR DESCRIPTION
Hi, I really appreciate pass-tomb, great tool. When using it I noticed some typos/wording choices that seemed a bit off. And I decided to go over the repo and try to correct those. I do hope you don't see this as too pedantic, and it's all up to you offcourse. In other words, these are just suggestions, the program works just fine without them.

One thing I do think is worthwhile are the changes to the examples in README.md and pass-tomb.1. In both files the examples for opening/closing a tomb are interchanged, causing some confusion.

Again, thanks for offering this important extension to pass and your coding efforts.

Kind regards,

glitsj16