### PR TITLE
Failed to set timer

### DIFF
--- a/tomb.bash
+++ b/tomb.bash
@@ -103,7 +103,7 @@ _timer() {
 		--setenv="PASSWORD_STORE_TOMB_FILE=$TOMB_FILE" \
 		--setenv="PASSWORD_STORE_EXTENSIONS_DIR=$PASSWORD_STORE_EXTENSIONS_DIR" \
 		--setenv="PASSWORD_STORE_ENABLE_EXTENSIONS=$PASSWORD_STORE_ENABLE_EXTENSIONS" \
-		/usr/bin/bash -c '/usr/bin/pass close --verbose' &> "$TMP"
+		bash -c '/usr/bin/pass close --verbose' &> "$TMP"
 	ret=$?
 	while read -r ii; do
 		_verbose "$ii"


### PR DESCRIPTION
This was specifically when running open `pass open --timer 1m`, but I imagine it applies to any use of timer:

```
$ pass open -v -f --timer 1m
  .  pass Opening the password tomb /home/foo/.password.tomb using the key /home/foo/.password.tomb.key
  .  tomb  .  Commanded to open tomb /home/foo/.password.tomb
  .  tomb  .  Valid tomb file found: /home/foo/.password.tomb
  .  tomb  .  Key is valid.
  .  tomb (*) Opening .password on /home/foo/.password-store/
  .  tomb  .  This tomb is a valid LUKS encrypted device.
  .  tomb  .  Cipher is "aes" mode "xts-plain64:sha256" hash "sha256"
  .  tomb (*) Success unlocking tomb .password
  .  tomb  .  Checking filesystem via /dev/loop17
  .  fsck from util-linux 2.31.1
  .  .password: clean, 98/2048 files, 1462/8192 blocks
  .  tomb (*) Success opening .password.tomb on /home/foo/.password-store/
  .  tomb  .  Last visit by foo(1000) from /dev/pts/10 on bar
  .  tomb  .  on date Wed 06 Jun 2018 02:17:02 PM EDT
  .  pass Setting user permissions on /home/foo/.password-store/
  .  pass Failed to find executable /usr/bin/bash: No such file or directory
  w  Unable to set the timer to close the password tomb in 1m.
 (*) Your password tomb has been opened in /home/foo/.password-store/.
  .  You can now use pass as usual.
  .  When finished, close the password tomb using 'pass close'.
```

The bash executable is not always located at /usr/bin/bash (such as on
Ubuntu 18.04 systems). systemd-run only requires an absolute path when
running a .service unit, from the docs:

https://www.freedesktop.org/software/systemd/man/systemd-run.html
> If a command is run as service unit, the first argument needs to be
an absolute program path.

Because the tomb.bash is already using env in the shebang, bash is
likely to be on the PATH.