### PR TITLE
Timer is used as user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ install:
 	@install -Dm0755 open.bash "$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/open.bash"
 	@install -Dm0755 close.bash "$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/close.bash"
 	@install -Dm0755 timer.bash "$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/timer.bash"
-	@install -Dm0644 pass-close@.service "$(DESTDIR)$(LIBDIR)/systemd/system/pass-close@.service"
+	@install -Dm0644 pass-close@.service "$(DESTDIR)$(LIBDIR)/systemd/user/pass-close@.service"
 	@install -Dm0644 share/pass-$(PROG).1 "$(DESTDIR)$(MANDIR)/man1/pass-$(PROG).1"
 	@install -Dm0644 share/pass-$(PROG).bash "$(DESTDIR)$(BASHCOMPDIR)/pass-$(PROG)"
 	@install -Dm0644 share/pass-$(PROG).zsh "$(DESTDIR)$(ZSHCOMPDIR)/_pass-$(PROG)"
@@ -33,7 +33,7 @@ uninstall:
 		"$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/open.bash" \
 		"$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/close.bash" \
 		"$(DESTDIR)$(SYSTEM_EXTENSION_DIR)/timer.bash" \
-		"$(DESTDIR)$(LIBDIR)/systemd/system/pass-close@.service" \
+		"$(DESTDIR)$(LIBDIR)/systemd/user/pass-close@.service" \
 		"$(DESTDIR)$(MANDIR)/man1/pass-$(PROG).1" \
 		"$(DESTDIR)$(BASHCOMPDIR)/pass-$(PROG)" \
 		"$(DESTDIR)$(ZSHCOMPDIR)/_pass-$(PROG)" \

--- a/tomb.bash
+++ b/tomb.bash
@@ -102,7 +102,7 @@ _timer() {
 	_tmp_create
 	_tomb_name="${TOMB_FILE##*/}"
 	_tomb_name="${_tomb_name%.tomb}"
-	sudo systemd-run --system --on-active="$delay" \
+	sudo systemd-run --user --on-active="$delay" \
 	                 --description="pass-close timer" \
 	                 --unit="pass-close@$_tomb_name.service" \
 	                 &> "$TMP"
@@ -376,6 +376,6 @@ while true; do case $1 in
 	--) shift; break ;;
 esac done
 
-[[ -z "$TIMER" ]] || command -v systemd-run &> /dev/null || _die "systemd-run is not present."
+[[ -z "$TIMER" ]] || command -v systemd-run --user &> /dev/null || _die "systemd-run is not present."
 [[ $err -ne 0 ]] && cmd_tomb_usage && exit 1
 [[ "$COMMAND" == "tomb" ]] && cmd_tomb "$id_path" "$@"

--- a/tomb.bash
+++ b/tomb.bash
@@ -257,11 +257,11 @@ cmd_timer() {
 	_tomb_name="${_tomb_name%.tomb}"
 	[[ -z "$_tomb_name" ]] && _die "There is no password tomb."
 
-	if systemctl is-active "pass-close@$_tomb_name.timer" &> /dev/null; then
-		systemctl status "pass-close@$_tomb_name.timer"
+	if systemctl --user is-active "pass-close@$_tomb_name.timer" &> /dev/null; then
+		systemctl --user status "pass-close@$_tomb_name.timer"
 	else
 		_warning "There is no active timer for $_tomb_file."
-		sudo systemctl status "pass-close@$_tomb_name.service"
+		systemctl --user status "pass-close@$_tomb_name.service"
 	fi
 
 	return 0


### PR DESCRIPTION
Timer is installed and used as user not system wide `systemd`.
Also should resolve #17, because switching user will not be required.