### PR TITLE
Permit specify options without environment variables too v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ pass tomb 1.3 - A pass extension that helps to keep the whole tree of
                 password encrypted inside a tomb.
 
 Usage:
-    pass tomb [-n] [-t time] [-f] [-p subfolder] gpg-id...
+    pass tomb [-n] [-t time] [-f] [-p subfolder] [-s size] gpg-id...
         Create and initialise a new password tomb
         Use gpg-id for encryption of both tomb and passwords
 
-    pass open [subfolder] [-t time] [-f]
+    pass open [subfolder] [-t time] [-k key] [--file tomb] [-f]
         Open a password tomb
 
     pass close [store]
@@ -46,6 +46,9 @@ Options:
     -n, --no-init  Do not initialise the password store
     -t, --timer    Close the store after a given time
     -p, --path     Create the store for that specific subfolder
+    -k, --key      Specify the path to the password tomb key
+    --file         Specify the tomb file to open 
+    -s, --size     Specify the tomb size in MB
     -f, --force    Force operation (i.e. even if swap is active)
     -q, --quiet    Be quiet
     -v, --verbose  Be verbose

--- a/share/man/man1/pass-tomb.md
+++ b/share/man/man1/pass-tomb.md
@@ -31,7 +31,7 @@ It uses the same GPG key to encrypt passwords and tomb, therefore you don't need
 
 # COMMAND
 
-## **pass tomb** [ *--no-init*, *-n* ] [ *--timer=time*, *-t time* ] [ *--path=subfolder*, *-p subfolder* ] [*--force*, *-f*] *gpg-id...*
+## **pass tomb** [ *--no-init*, *-n* ] [ *--timer=time*, *-t time* ] [ *--path=subfolder*, *-p subfolder* ] [*--force*, *-f*] [*--size=size*, *-s size*] *gpg-id...*
 
 Create and initialize a new password tomb. This command must be run first, before a password store can be used.
 
@@ -43,6 +43,9 @@ Create and initialize a new password tomb. This command must be run first, befor
 `--path=subfolder`, `-p subfolder`
 
 :   Specific password tomb using *gpg-id* or a set of gpg-ids is assigned for that specific subfolder of the password store.
+
+
+`--=subfolder`, `-p subfolder`
 
 `--no-init`, `-n`
 
@@ -56,8 +59,12 @@ Create and initialize a new password tomb. This command must be run first, befor
 
 :   Force the password store to be mounted or created even if a plain text swap is present. Make sure you know what you are doing if you force an operation.
 
+`--size`, `-s`
 
-## **pass open** [ *--timer=time*, *-t time* ] [*--force*, *-f*] [*subfolder*]
+:   Specify the tomb size in MB.
+
+
+## **pass open** [ *--timer=time*, *-t time* ] [*--force*, *-f*] [*--key=key*, *-k key*] [*subfolder*]
 
 Open a password tomb. If a *.timer* file is present in the store, a systemd timer will be initialized.
 
@@ -72,6 +79,14 @@ Open a password tomb. If a *.timer* file is present in the store, a systemd time
 `--force`, `-f`
 
 :   Force the password store to be mounted or created even if a plain text swap is present. Make sure you know what you are doing if you force an operation.
+
+`--key`, `-k`
+
+:   Specify the path to the password tomb key.
+
+`--file`
+
+:   Specify the path to the password tomb. 
 
 
 ## **pass close** [*store*]
@@ -103,6 +118,18 @@ Show timer status.
 **`-p`, `--path`**
 
 :   Create the store for that specific subfolder
+
+**`-k`, `--key`**
+
+:   Specify the tomb key to open the store
+
+**`--file`**
+
+:   Specify the tomb file to open 
+
+**`-s`, `--size`**
+
+:   Specify the tomb size in MB
 
 **`-f`, `--force`**
 

--- a/tomb.bash
+++ b/tomb.bash
@@ -5,10 +5,10 @@
 
 set -e -o pipefail
 
-readonly TOMB="${PASSWORD_STORE_TOMB:-tomb}"
-readonly TOMB_FILE="${PASSWORD_STORE_TOMB_FILE:-$HOME/.password.tomb}"
-readonly TOMB_KEY="${PASSWORD_STORE_TOMB_KEY:-$HOME/.password.tomb.key}"
-readonly TOMB_SIZE="${PASSWORD_STORE_TOMB_SIZE:-30}"
+TOMB="${PASSWORD_STORE_TOMB:-tomb}"
+TOMB_FILE="${PASSWORD_STORE_TOMB_FILE:-$HOME/.password.tomb}"
+TOMB_KEY="${PASSWORD_STORE_TOMB_KEY:-$HOME/.password.tomb.key}"
+TOMB_SIZE="${PASSWORD_STORE_TOMB_SIZE:-30}"
 
 readonly VERSION="1.3"
 
@@ -149,11 +149,11 @@ cmd_tomb_usage() {
 	echo
 	cat <<-_EOF
 		Usage:
-		    $PROGRAM tomb [-n] [-t time] [-f] [-p subfolder] gpg-id...
+		    $PROGRAM tomb [-n] [-t time] [-f] [-p subfolder] [-s size] gpg-id...
 		        Create and initialise a new password tomb
 		        Use gpg-id for encryption of both tomb and passwords
 
-		    $PROGRAM open [subfolder] [-t time] [-f]
+		    $PROGRAM open [subfolder] [-t time] [-k key] [--file tomb] [-f]
 		        Open a password tomb
 
 		    $PROGRAM close [store]
@@ -166,6 +166,9 @@ cmd_tomb_usage() {
 		    -n, --no-init  Do not initialise the password store
 		    -t, --timer    Close the store after a given time
 		    -p, --path     Create the store for that specific subfolder
+                    -k, --key      Specify the path to the password tomb key
+                    --file         Specify the path to the password tomb
+                    -s, --size     Specify the tomb size in MB
 		    -f, --force    Force operation (i.e. even if swap is active)
 		    -q, --quiet    Be quiet
 		    -v, --verbose  Be verbose
@@ -346,8 +349,8 @@ NOINIT=0
 TIMER=""
 
 # Getopt options
-small_arg="vdhVp:qnt:f"
-long_arg="verbose,debug,help,version,path:,unsafe,quiet,no-init,timer:,force"
+small_arg="vdhVp:k:s:qnt:f"
+long_arg="verbose,debug,help,version,path:,key:,file:,unsafe,quiet,no-init,timer:,force"
 opts="$($GETOPT -o $small_arg -l $long_arg -n "$PROGRAM $COMMAND" -- "$@")"
 err=$?
 eval set -- "$opts"
@@ -387,6 +390,18 @@ while true; do case $1 in
 		;;
 	-t | --timer)
 		TIMER="$2"
+		shift 2
+		;;
+	-k | --key)
+		TOMB_KEY="$2"
+		shift 2
+		;;
+	--file)
+		TOMB_FILE="$2"
+		shift 2
+		;;
+	-s | --size)
+		TOMB_SIZE="$2"
 		shift 2
 		;;
 	-n | --no-init)


### PR DESCRIPTION
I frequently use this program and have found it cumbersome to specify environment variables each time. Additionally, I prefer not to set these variables in my configuration files. I would greatly appreciate it if you could consider adding this functionality to allow for specifying options without relying on environment variables. Thank you for your attention!